### PR TITLE
Updated import message strings for issues 67 and 68

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,10 +34,37 @@
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="http"
+                    android:host="*"
+                    android:pathPattern=".*\\.txc"
+                    android:mimeType="*/*" />
+                <data
+                    android:scheme="https"
+                    android:host="*"
+                    android:pathPattern=".*\\.txc"
+                    android:mimeType="*/*" />
+                <data
+                    android:scheme="ftp"
+                    android:host="*"
+                    android:pathPattern=".*\\.txc"
+                    android:mimeType="*/*" />
+                <data
+                    android:scheme="sftp"
+                    android:host="*"
+                    android:pathPattern=".*\\.txc"
+                    android:mimeType="*/*" />
                 <data
                     android:scheme="file"
                     android:host="*"
-                    android:pathPattern="/.*\\.txc" />
+                    android:pathPattern=".*\\.txc"
+                    android:mimeType="*/*" />
+                <data
+                    android:scheme="content"
+                    android:host="*"
+                    android:pathPattern=".*\\.txc"
+                    android:mimeType="*/*" />
             </intent-filter>
             <!-- To support opening downloaded files.
                  It appears that downloaded files are re-assigned numeric filenames, so we can't
@@ -48,24 +75,17 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data
                     android:scheme="content"
+                    android:host="*"
                     android:mimeType="application/octet-stream" />
                 <data
                     android:scheme="content"
+                    android:host="*"
                     android:mimeType="application/zip" />
                 <data
                     android:scheme="content"
+                    android:host="*"
                     android:mimeType="application/x-zip" />
-                <data
-                    android:scheme="file"
-                    android:mimeType="application/octet-stream" />
-                <data
-                    android:scheme="file"
-                    android:mimeType="application/zip" />
-                <data
-                    android:scheme="file"
-                    android:mimeType="application/x-zip" />
-            </intent-filter>
+            </intent-filter> -->
         </activity>
     </application>
-
 </manifest>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,12 +23,12 @@
     <string name="navigation_button_next">NEXT</string>
     <string name="navigation_button_save">SAVE</string>
     <string name="import_confirm_alert_title">Confirm import</string>
-    <string name="import_confirm_alert_message">Are you sure you want to import these cards?</string>
+    <string name="import_confirm_alert_message">Import Translation Cards deck?</string>
     <string name="import_confirm_alert_positive">Import</string>
     <string name="import_confirm_alert_negative">Cancel</string>
     <string name="import_failure_alert_title">Failure</string>
     <string name="import_failure_default_error_message">Importing failed.</string>
-    <string name="import_failure_file_not_found_error_message">Target file could not be found.</string>
+    <string name="import_failure_file_not_found_error_message">Translation Cards deck file is invalid.</string>
     <string name="import_failure_no_index_file_error_message">TXC file did not have an index.</string>
     <string name="import_failure_invalid_index_file_error_message">TXC file index was invalid.</string>
     <string name="import_failure_read_error_error_message">Error reading TXC file or its contents.</string>


### PR DESCRIPTION
Updated error messages to close issues 67 and 68.

Bizarrely, ContentResolver.openInputStream does not distinguish been "file not found" and "file corrupt" in the exception it throws. 

But for our uses, the FileNotFound error will always be thrown for invalid files, not somehow missing ones, so I just changed the string from "not found" to "invalid"