### PR TITLE
Deck addition

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,7 @@
        </activity>
         <activity android:name=".activity.RecordingActivity"
             android:screenOrientation="portrait"/>
+        <activity android:name=".activity.DeckCreationActivity" />
         <activity android:name=".activity.ImportActivity">
             <!-- To support opening from a file manager. -->
             <intent-filter>

--- a/app/src/main/java/org/mercycorps/translationcards/activity/DeckCreationActivity.java
+++ b/app/src/main/java/org/mercycorps/translationcards/activity/DeckCreationActivity.java
@@ -1,0 +1,45 @@
+package org.mercycorps.translationcards.activity;
+
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+import android.widget.EditText;
+
+import org.mercycorps.translationcards.R;
+import org.mercycorps.translationcards.data.DbManager;
+
+import java.util.Date;
+
+public class DeckCreationActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        initView();
+    }
+
+    private void initView() {
+        setContentView(R.layout.activity_deck_creation);
+        final EditText deckNameField = (EditText) findViewById(R.id.field_deck_name);
+        final EditText targetLanguagesField = (EditText) findViewById(R.id.field_target_languages);
+        findViewById(R.id.button_add_deck).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                DbManager dbm = new DbManager(DeckCreationActivity.this);
+                long deckId = dbm.addDeck(
+                        deckNameField.getText().toString(), // label
+                        getString(R.string.misc_self), // publisher
+                        (new Date()).getTime(), // timestamp
+                        null, // no external ID
+                        null, // hash not relevant
+                        false); // not locked
+                String[] languages = targetLanguagesField.getText().toString().split(",");
+                for (int i = 0; i < languages.length; i++) {
+                    dbm.addDictionary(languages[i], i, deckId);
+                }
+                setResult(RESULT_OK);
+                finish();
+            }
+        });
+    }
+}

--- a/app/src/main/java/org/mercycorps/translationcards/activity/DecksActivity.java
+++ b/app/src/main/java/org/mercycorps/translationcards/activity/DecksActivity.java
@@ -46,6 +46,7 @@ public class DecksActivity extends AppCompatActivity {
 
     private static final int REQUEST_CODE_IMPORT_FILE_PICKER = 1;
     private static final int REQUEST_CODE_IMPORT_FILE = 2;
+    private static final int REQUEST_CODE_CREATE_DECK = 3;
 
     private DbManager dbManager;
 
@@ -77,9 +78,24 @@ public class DecksActivity extends AppCompatActivity {
         findViewById(R.id.add_button).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
-                intent.setType("file/*");
-                startActivityForResult(intent, REQUEST_CODE_IMPORT_FILE_PICKER);
+                AlertDialog.Builder builder = new AlertDialog.Builder(DecksActivity.this);
+                builder.setItems(R.array.deck_add_options, new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int which) {
+                        switch (which) {
+                            case 0:
+                                Intent fileIntent = new Intent(Intent.ACTION_GET_CONTENT);
+                                fileIntent.setType("file/*");
+                                startActivityForResult(fileIntent, REQUEST_CODE_IMPORT_FILE_PICKER);
+                                break;
+                            case 1:
+                                Intent createIntent =
+                                        new Intent(DecksActivity.this, DeckCreationActivity.class);
+                                startActivityForResult(createIntent, REQUEST_CODE_CREATE_DECK);
+                                break;
+                        }
+                    }
+                });
+                builder.show();
             }
         });
     }
@@ -254,6 +270,11 @@ public class DecksActivity extends AppCompatActivity {
                 startActivityForResult(intent, REQUEST_CODE_IMPORT_FILE);
                 break;
             case REQUEST_CODE_IMPORT_FILE:
+                if (resultCode == RESULT_OK) {
+                    initDecks();
+                }
+                break;
+            case REQUEST_CODE_CREATE_DECK:
                 if (resultCode == RESULT_OK) {
                     initDecks();
                 }

--- a/app/src/main/java/org/mercycorps/translationcards/activity/DecksActivity.java
+++ b/app/src/main/java/org/mercycorps/translationcards/activity/DecksActivity.java
@@ -7,6 +7,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -37,17 +38,22 @@ import java.util.Random;
  * @author patdale216@gmail.com (Pat Dale)
  */
 public class DecksActivity extends AppCompatActivity {
+
     private static final String FEEDBACK_URL =
             "https://docs.google.com/forms/d/1p8nJlpFSv03MXWf67pjh_fHyOfjbK9LJgF8hORNcvNM/" +
                     "viewform?entry.1158658650=0.3.1";
     public static final String INTENT_KEY_DECK_ID = "Deck";
-    private DbManager dbManager;
 
+    private static final int REQUEST_CODE_IMPORT_FILE_PICKER = 1;
+    private static final int REQUEST_CODE_IMPORT_FILE = 2;
+
+    private DbManager dbManager;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_decks);
+        initAddButton();
         initFeedbackButton();
         dbManager = new DbManager(this);
         initDecks();
@@ -65,7 +71,17 @@ public class DecksActivity extends AppCompatActivity {
         for (Deck deck : dbManager.getAllDecks()) {
             listAdapter.add(deck);
         }
+    }
 
+    private void initAddButton() {
+        findViewById(R.id.add_button).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+                intent.setType("file/*");
+                startActivityForResult(intent, REQUEST_CODE_IMPORT_FILE_PICKER);
+            }
+        });
     }
 
     private void initFeedbackButton() {
@@ -224,5 +240,24 @@ public class DecksActivity extends AppCompatActivity {
                             public void onClick(DialogInterface dialog, int which) {}
                         })
                 .show();
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        switch(requestCode) {
+            case REQUEST_CODE_IMPORT_FILE_PICKER:
+                if (resultCode != RESULT_OK) {
+                    return;
+                }
+                Intent intent = new Intent(this, ImportActivity.class);
+                intent.setData(data.getData());
+                startActivityForResult(intent, REQUEST_CODE_IMPORT_FILE);
+                break;
+            case REQUEST_CODE_IMPORT_FILE:
+                if (resultCode == RESULT_OK) {
+                    initDecks();
+                }
+                break;
+        }
     }
 }

--- a/app/src/main/res/layout/activity_deck_creation.xml
+++ b/app/src/main/res/layout/activity_deck_creation.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/deck_creation_field_label_deck_name" />
+
+    <EditText
+        android:id="@+id/field_deck_name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/deck_creation_field_label_target_languages" />
+
+    <EditText
+        android:id="@+id/field_target_languages"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <Button
+        android:id="@+id/button_add_deck"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/deck_creation_add_button" />
+</LinearLayout>

--- a/app/src/main/res/layout/activity_decks.xml
+++ b/app/src/main/res/layout/activity_decks.xml
@@ -11,4 +11,15 @@
         android:divider="@color/listBackgroundColor"
         android:dividerHeight="20dp"
         android:id="@+id/decks_list"/>
+
+    <ImageButton
+        android:layout_width="74dp"
+        android:layout_height="78dp"
+        android:background="@drawable/add_button"
+        android:id="@+id/add_button"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentRight="true"
+        android:layout_alignParentEnd="true"
+        android:layout_marginRight="12dp"
+        android:layout_marginBottom="4dp" />
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,14 @@
     <string name="recording_text_hint_text">Phrase translation (Optional)</string>
     <string name="recording_done_title">New %s flashcard created</string>
     <string name="recording_done_detail">Find your new flashcard at the top of the list in the %s category.</string>
+    <string name="deck_creation_field_label_deck_name">Deck Name:</string>
+    <string name="deck_creation_field_label_target_languages">Target Languages (comma-separated):</string>
+    <string name="deck_creation_add_button">Add Deck</string>
+    <!-- The order of these is important! Don't move them around without updating DecksActivity. -->
+    <string-array name="deck_add_options">
+        <item>Import from file</item>
+        <item>Create fresh deck</item>
+    </string-array>
     <string name="navigation_button_back">BACK</string>
     <string name="navigation_button_done">DONE</string>
     <string name="navigation_button_next">NEXT</string>
@@ -40,6 +48,7 @@
     <string name="export_failure_too_many_duplicate_filenames_error_message">Too many duplicate filenames.</string>
     <string name="misc_ok">OK</string>
     <string name="misc_cancel">Cancel</string>
+    <string name="misc_self">Self</string>
     <string name="data_default_deck_name">Default</string>
     <string name="my_decks">My Decks</string>
     <string name="data_default_deck_publisher">My Deck</string>


### PR DESCRIPTION
Provides two options in the app for adding a deck:
- An import button that opens a file manager (if one is available) and then sends it to the import activity.
- A screen where you can specify a deck name and target languages and create a new deck; as promised, it's a bare minimum UI. Unless adding decks in the app is a really urgent requirement, we'll probably want to hold off on bringing this into master until the UI isn't terrible.