### PR TITLE
JSON importing and exporting

### DIFF
--- a/app/src/main/java/org/mercycorps/translationcards/activity/DeckCreationActivity.java
+++ b/app/src/main/java/org/mercycorps/translationcards/activity/DeckCreationActivity.java
@@ -37,7 +37,7 @@ public class DeckCreationActivity extends AppCompatActivity {
                                // screen's limitations)
                 String[] languages = targetLanguagesField.getText().toString().split(",");
                 for (int i = 0; i < languages.length; i++) {
-                    dbm.addDictionary(languages[i], i, deckId);
+                    dbm.addDictionary(languages[i], "", i, deckId);
                 }
                 setResult(RESULT_OK);
                 finish();

--- a/app/src/main/java/org/mercycorps/translationcards/activity/DeckCreationActivity.java
+++ b/app/src/main/java/org/mercycorps/translationcards/activity/DeckCreationActivity.java
@@ -32,7 +32,9 @@ public class DeckCreationActivity extends AppCompatActivity {
                         (new Date()).getTime(), // timestamp
                         null, // no external ID
                         null, // hash not relevant
-                        false); // not locked
+                        false, // not locked
+                        "en"); // for now, we assume English (certainly not the least of this
+                               // screen's limitations)
                 String[] languages = targetLanguagesField.getText().toString().split(",");
                 for (int i = 0; i < languages.length; i++) {
                     dbm.addDictionary(languages[i], i, deckId);

--- a/app/src/main/java/org/mercycorps/translationcards/activity/DecksActivity.java
+++ b/app/src/main/java/org/mercycorps/translationcards/activity/DecksActivity.java
@@ -20,6 +20,7 @@ import org.mercycorps.translationcards.data.DbManager;
 import org.mercycorps.translationcards.R;
 import org.mercycorps.translationcards.data.Deck;
 import org.mercycorps.translationcards.data.Dictionary;
+import org.mercycorps.translationcards.ui.LanguageDisplayUtil;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -147,7 +148,9 @@ public class DecksActivity extends AppCompatActivity {
 
             TextView translationLanguagesView =
                     (TextView) convertView.findViewById(R.id.translation_languages);
-            translationLanguagesView.setText(dbManager.getTranslationLanguagesForDeck(deck.getDbId()));
+            Dictionary[] dictionaries = deck.getDictionaries(DecksActivity.this);
+            translationLanguagesView.setText(LanguageDisplayUtil.getDestLanguageListDisplay(
+                    DecksActivity.this, deck, "  "));
 
             View deckCopyView = convertView.findViewById(R.id.deck_card_expansion_copy);
             if (deck.isLocked()) {

--- a/app/src/main/java/org/mercycorps/translationcards/activity/DecksActivity.java
+++ b/app/src/main/java/org/mercycorps/translationcards/activity/DecksActivity.java
@@ -202,7 +202,8 @@ public class DecksActivity extends AppCompatActivity {
         try {
             for (Dictionary dictionary : dictionaries) {
                 long dictionaryId = dbm.addDictionary(
-                        dictionary.getLabel(), dictionaryIndex, deckId);
+                        dictionary.getDestLanguageIso(), dictionary.getLabel(), dictionaryIndex,
+                        deckId);
                 dictionaryIndex--;
                 int translationDbIndex = dictionary.getTranslationCount() - 1;
                 for (int i = 0; i < dictionary.getTranslationCount(); i++) {

--- a/app/src/main/java/org/mercycorps/translationcards/activity/DecksActivity.java
+++ b/app/src/main/java/org/mercycorps/translationcards/activity/DecksActivity.java
@@ -195,7 +195,8 @@ public class DecksActivity extends AppCompatActivity {
                 String.format("copy-%d", (new Random()).nextInt()));
         targetDir.mkdirs();
         DbManager dbm = new DbManager(this);
-        long deckId = dbm.addDeck(deckName, getString(R.string.data_self_publisher), (new Date()).getTime(), null, null, false);
+        long deckId = dbm.addDeck(deckName, getString(R.string.data_self_publisher), (new Date()).getTime(), null, null, false,
+                deck.getSrcLanguageIso());
         Dictionary[] dictionaries = dbm.getAllDictionariesForDeck(deck.getDbId());
         int dictionaryIndex = dictionaries.length - 1;
         try {

--- a/app/src/main/java/org/mercycorps/translationcards/activity/ImportActivity.java
+++ b/app/src/main/java/org/mercycorps/translationcards/activity/ImportActivity.java
@@ -46,23 +46,23 @@ public class ImportActivity extends AppCompatActivity {
 
     private void attemptImport(Uri source) {
         try {
-            TxcPortingUtility.ImportInfo importInfo =
+            TxcPortingUtility.ImportSpec importSpec =
                     portingUtility.prepareImport(ImportActivity.this, source);
             // Check if it's a deck we've already imported.
-            if (false && portingUtility.isExistingDeck(this, importInfo)) {
-                portingUtility.abortImport(this, importInfo);
+            if (false && portingUtility.isExistingDeck(this, importSpec)) {
+                portingUtility.abortImport(this, importSpec);
                 alertUserOfFailure(getString(R.string.import_failure_existing_deck));
                 return;
             }
             // Check if it's a different version of a deck we've already imported.
-            if (importInfo.externalId != null && !importInfo.externalId.isEmpty()) {
-                long otherVersion = portingUtility.otherVersionExists(this, importInfo);
+            if (importSpec.externalId != null && !importSpec.externalId.isEmpty()) {
+                long otherVersion = portingUtility.otherVersionExists(this, importSpec);
                 if (otherVersion != -1) {
-                    handleVersionOverride(importInfo, otherVersion);
+                    handleVersionOverride(importSpec, otherVersion);
                     return;
                 }
             }
-            portingUtility.executeImport(this, importInfo);
+            portingUtility.executeImport(this, importSpec);
         } catch (ImportException e) {
             handleError(e);
             return;
@@ -71,7 +71,7 @@ public class ImportActivity extends AppCompatActivity {
     }
 
     private void handleVersionOverride(
-            final TxcPortingUtility.ImportInfo importInfo, final long otherVersion) {
+            final TxcPortingUtility.ImportSpec importSpec, final long otherVersion) {
         AlertDialog.Builder builder = new AlertDialog.Builder(this);
         builder.setTitle(R.string.import_version_override_title)
                 .setItems(R.array.version_override_options, new DialogInterface.OnClickListener() {
@@ -82,7 +82,7 @@ public class ImportActivity extends AppCompatActivity {
                                 break;
                             case 1:
                                 try {
-                                    portingUtility.executeImport(ImportActivity.this, importInfo);
+                                    portingUtility.executeImport(ImportActivity.this, importSpec);
                                 } catch (ImportException e) {
                                     handleError(e);
                                     return;
@@ -91,7 +91,7 @@ public class ImportActivity extends AppCompatActivity {
                                 break;
                             case 2:
                                 try {
-                                    portingUtility.executeImport(ImportActivity.this, importInfo);
+                                    portingUtility.executeImport(ImportActivity.this, importSpec);
                                 } catch (ImportException e) {
                                     handleError(e);
                                     return;

--- a/app/src/main/java/org/mercycorps/translationcards/activity/RecordingActivity.java
+++ b/app/src/main/java/org/mercycorps/translationcards/activity/RecordingActivity.java
@@ -69,7 +69,7 @@ public class RecordingActivity extends AppCompatActivity {
     private static final String TAG = "RecordingActivity";
 
     public static final String INTENT_KEY_DICTIONARY_ID = "dictionaryId";
-    public static final String INTENT_KEY_DICTIONARY_LABEL = "dictionaryLabel";
+    public static final String INTENT_KEY_DICTIONARY_DISPLAY_NAME = "dictionaryDisplayName";
     public static final String INTENT_KEY_TRANSLATION_ID = "translationId";
     public static final String INTENT_KEY_TRANSLATION_LABEL = "translationLabel";
     public static final String INTENT_KEY_TRANSLATION_IS_ASSET = "translationIsAsset";
@@ -101,7 +101,7 @@ public class RecordingActivity extends AppCompatActivity {
     private RecordingStatus recordingStatus;
     private boolean inEditMode;
     private long dictionaryId;
-    private String dictionaryLabel;
+    private String dictionaryDisplayName;
     private long translationId;
     private String label;
     private boolean isAsset;
@@ -123,7 +123,7 @@ public class RecordingActivity extends AppCompatActivity {
         mediaPlayerManager = application.getMediaPlayerManager();
         stepHistory = new Stack<>();
         dictionaryId = getIntent().getLongExtra(INTENT_KEY_DICTIONARY_ID, -1);
-        dictionaryLabel = getIntent().getStringExtra(INTENT_KEY_DICTIONARY_LABEL);
+        dictionaryDisplayName = getIntent().getStringExtra(INTENT_KEY_DICTIONARY_DISPLAY_NAME);
         translationId = getIntent().getLongExtra(INTENT_KEY_TRANSLATION_ID, -1);
         label = getIntent().getStringExtra(INTENT_KEY_TRANSLATION_LABEL);
         translatedText = getIntent().getStringExtra(INTENT_KEY_TRANSLATION_TEXT);
@@ -177,7 +177,7 @@ public class RecordingActivity extends AppCompatActivity {
         currentBitmapView = (ImageView) findViewById(R.id.recording_instructions_image);
         currentBitmapView.setImageBitmap(currentBitmap);
         TextView titleView = (TextView) findViewById(R.id.recording_instructions_title);
-        titleView.setText(getString(R.string.recording_instructions_title, dictionaryLabel));
+        titleView.setText(getString(R.string.recording_instructions_title, dictionaryDisplayName));
         ImageButton backButton = (ImageButton) findViewById(R.id.recording_instructions_back);
         backButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -205,7 +205,7 @@ public class RecordingActivity extends AppCompatActivity {
     private void moveToLabelStep() {
         setContentView(R.layout.recording_label);
         TextView labelTitle = (TextView) findViewById(R.id.recording_label_title);
-        labelTitle.setText(getString(R.string.recording_label_create_title, dictionaryLabel));
+        labelTitle.setText(getString(R.string.recording_label_create_title, dictionaryDisplayName));
         recycleBitmap();
         currentBitmap = BitmapFactory.decodeResource(
                 getResources(), R.drawable.recording_label_image);
@@ -214,7 +214,8 @@ public class RecordingActivity extends AppCompatActivity {
         final EditText labelField = (EditText) findViewById(R.id.recording_label_field);
         final EditText translatedTextField = (EditText) findViewById(R.id.recording_translated_text_field);
         fillPrepopulatedField(label, labelField, getString(R.string.recording_label_hint_text));
-        fillPrepopulatedField(translatedText, translatedTextField, String.format(getString(R.string.translated_text_hint), dictionaryLabel));
+        fillPrepopulatedField(translatedText, translatedTextField,
+                String.format(getString(R.string.translated_text_hint), dictionaryDisplayName));
         if (inEditMode) {
             ImageView deleteButton = (ImageView) findViewById(R.id.recording_label_delete_image);
             deleteButton.setVisibility(View.VISIBLE);
@@ -341,7 +342,7 @@ public class RecordingActivity extends AppCompatActivity {
         }
         recycleBitmap();
         TextView titleView = (TextView) findViewById(R.id.recording_audio_title);
-        titleView.setText(getString(R.string.recording_audio_title, dictionaryLabel));
+        titleView.setText(getString(R.string.recording_audio_title, dictionaryDisplayName));
         TextView labelView = (TextView) findViewById(R.id.origin_translation_text);
         labelView.setText(label);
         findViewById(R.id.translation_indicator_layout).setVisibility(View.GONE);
@@ -522,14 +523,14 @@ public class RecordingActivity extends AppCompatActivity {
         currentBitmapView = (ImageView) findViewById(R.id.recording_done_image);
         currentBitmapView.setImageBitmap(currentBitmap);
         TextView titleView = (TextView) findViewById(R.id.recording_done_title);
-        titleView.setText(getString(R.string.recording_done_title, dictionaryLabel));
+        titleView.setText(getString(R.string.recording_done_title, dictionaryDisplayName));
         TextView detailView = (TextView) findViewById(R.id.recording_done_detail);
-        detailView.setText(getString(R.string.recording_done_detail, dictionaryLabel));
+        detailView.setText(getString(R.string.recording_done_detail, dictionaryDisplayName));
         TextView cardTextView = (TextView) findViewById(R.id.origin_translation_text);
         cardTextView.setText(label);
         TextView translatedCardText = (TextView) findViewById(R.id.translated_text);
         if (translatedText.trim().isEmpty()) {
-            translatedCardText.setHint(String.format(getString(R.string.translated_text_hint), dictionaryLabel));
+            translatedCardText.setHint(String.format(getString(R.string.translated_text_hint), dictionaryDisplayName));
             translatedCardText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 18);
         } else {
             translatedCardText.setText(translatedText);

--- a/app/src/main/java/org/mercycorps/translationcards/activity/TranslationsActivity.java
+++ b/app/src/main/java/org/mercycorps/translationcards/activity/TranslationsActivity.java
@@ -118,7 +118,7 @@ public class TranslationsActivity extends RoboActionBarActivity {
             Dictionary dictionary = dictionaries[i];
             View textFrame = inflater.inflate(R.layout.language_tab, tabContainer, false);
             TextView textView = (TextView) textFrame.findViewById(R.id.tab_label_text);
-            textView.setText(dictionary.getLabel().toUpperCase());
+            textView.setText(dictionary.getDisplayName(this).toUpperCase());
             final int index = i;
             textFrame.setOnClickListener(new View.OnClickListener() {
                 @Override
@@ -184,8 +184,8 @@ public class TranslationsActivity extends RoboActionBarActivity {
         Intent intent = new Intent(this, RecordingActivity.class);
         intent.putExtra(RecordingActivity.INTENT_KEY_DICTIONARY_ID,
                 dictionaries[currentDictionaryIndex].getDbId());
-        intent.putExtra(RecordingActivity.INTENT_KEY_DICTIONARY_LABEL,
-                dictionaries[currentDictionaryIndex].getLabel());
+        intent.putExtra(RecordingActivity.INTENT_KEY_DICTIONARY_DISPLAY_NAME,
+                dictionaries[currentDictionaryIndex].getDisplayName(this));
         intent.putExtra(INTENT_KEY_DECK_ID, deck);
         startActivityForResult(intent, REQUEST_KEY_ADD_CARD);
     }
@@ -286,7 +286,8 @@ public class TranslationsActivity extends RoboActionBarActivity {
             TextView translatedText = (TextView) convertView.findViewById(R.id.translated_text);
             if(getItem(position).getTranslatedText().isEmpty()){
                 translatedText.setText(String.format(getString(R.string.translated_text_hint),
-                        dictionaries[currentDictionaryIndex].getLabel()));
+                        dictionaries[currentDictionaryIndex].getDisplayName(
+                                TranslationsActivity.this)));
                 translatedText.setTextColor(ContextCompat.getColor(getContext(),
                         R.color.textDisabled));
                 translatedText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 18);
@@ -345,7 +346,8 @@ public class TranslationsActivity extends RoboActionBarActivity {
             Intent intent = new Intent(TranslationsActivity.this, RecordingActivity.class);
             Dictionary dictionary = dictionaries[currentDictionaryIndex];
             intent.putExtra(RecordingActivity.INTENT_KEY_DICTIONARY_ID, dictionary.getDbId());
-            intent.putExtra(RecordingActivity.INTENT_KEY_DICTIONARY_LABEL, dictionary.getLabel());
+            intent.putExtra(RecordingActivity.INTENT_KEY_DICTIONARY_DISPLAY_NAME,
+                    dictionary.getDisplayName(TranslationsActivity.this));
             intent.putExtra(RecordingActivity.INTENT_KEY_TRANSLATION_ID, translationCard.getDbId());
             intent.putExtra(RecordingActivity.INTENT_KEY_TRANSLATION_LABEL,
                     translationCard.getLabel());

--- a/app/src/main/java/org/mercycorps/translationcards/activity/TranslationsActivity.java
+++ b/app/src/main/java/org/mercycorps/translationcards/activity/TranslationsActivity.java
@@ -49,6 +49,7 @@ import org.mercycorps.translationcards.R;
 import org.mercycorps.translationcards.porting.TxcPortingUtility;
 import org.mercycorps.translationcards.data.Deck;
 import org.mercycorps.translationcards.data.Dictionary;
+import org.mercycorps.translationcards.ui.LanguageDisplayUtil;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -118,7 +119,8 @@ public class TranslationsActivity extends RoboActionBarActivity {
             Dictionary dictionary = dictionaries[i];
             View textFrame = inflater.inflate(R.layout.language_tab, tabContainer, false);
             TextView textView = (TextView) textFrame.findViewById(R.id.tab_label_text);
-            textView.setText(dictionary.getDisplayName(this).toUpperCase());
+            textView.setText(
+                    LanguageDisplayUtil.getDestLanguageDisplayName(this, dictionary).toUpperCase());
             final int index = i;
             textFrame.setOnClickListener(new View.OnClickListener() {
                 @Override
@@ -185,7 +187,8 @@ public class TranslationsActivity extends RoboActionBarActivity {
         intent.putExtra(RecordingActivity.INTENT_KEY_DICTIONARY_ID,
                 dictionaries[currentDictionaryIndex].getDbId());
         intent.putExtra(RecordingActivity.INTENT_KEY_DICTIONARY_DISPLAY_NAME,
-                dictionaries[currentDictionaryIndex].getDisplayName(this));
+                LanguageDisplayUtil.getDestLanguageDisplayName(
+                        this, dictionaries[currentDictionaryIndex]));
         intent.putExtra(INTENT_KEY_DECK_ID, deck);
         startActivityForResult(intent, REQUEST_KEY_ADD_CARD);
     }
@@ -286,8 +289,8 @@ public class TranslationsActivity extends RoboActionBarActivity {
             TextView translatedText = (TextView) convertView.findViewById(R.id.translated_text);
             if(getItem(position).getTranslatedText().isEmpty()){
                 translatedText.setText(String.format(getString(R.string.translated_text_hint),
-                        dictionaries[currentDictionaryIndex].getDisplayName(
-                                TranslationsActivity.this)));
+                        LanguageDisplayUtil.getDestLanguageDisplayName(
+                                TranslationsActivity.this, dictionaries[currentDictionaryIndex])));
                 translatedText.setTextColor(ContextCompat.getColor(getContext(),
                         R.color.textDisabled));
                 translatedText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 18);
@@ -347,7 +350,8 @@ public class TranslationsActivity extends RoboActionBarActivity {
             Dictionary dictionary = dictionaries[currentDictionaryIndex];
             intent.putExtra(RecordingActivity.INTENT_KEY_DICTIONARY_ID, dictionary.getDbId());
             intent.putExtra(RecordingActivity.INTENT_KEY_DICTIONARY_DISPLAY_NAME,
-                    dictionary.getDisplayName(TranslationsActivity.this));
+                    LanguageDisplayUtil.getDestLanguageDisplayName(
+                            TranslationsActivity.this, dictionary));
             intent.putExtra(RecordingActivity.INTENT_KEY_TRANSLATION_ID, translationCard.getDbId());
             intent.putExtra(RecordingActivity.INTENT_KEY_TRANSLATION_LABEL,
                     translationCard.getLabel());

--- a/app/src/main/java/org/mercycorps/translationcards/data/DbManager.java
+++ b/app/src/main/java/org/mercycorps/translationcards/data/DbManager.java
@@ -89,6 +89,8 @@ public class DbManager {
         cursor.moveToFirst();
         while (dictionaryIndex < res.length) {
             long dictionaryId = cursor.getLong(cursor.getColumnIndex(DictionariesTable.ID));
+            String destLanguageIso = cursor.getString(cursor.getColumnIndex(
+                    DictionariesTable.LANGUAGE_ISO));
             String label = cursor.getString(cursor.getColumnIndex(DictionariesTable.LABEL));
             long deckId = cursor.getLong(cursor.getColumnIndex(DictionariesTable.DECK_ID));
             Dictionary.Translation[] languageTranslations = {};
@@ -97,7 +99,7 @@ public class DbManager {
                         .toArray(new Dictionary.Translation[] {});
             }
             res[dictionaryIndex] = new Dictionary(
-                    label, languageTranslations, dictionaryId, deckId);
+                    destLanguageIso, label, languageTranslations, dictionaryId, deckId);
             cursor.moveToNext();
             dictionaryIndex++;
         }
@@ -115,9 +117,12 @@ public class DbManager {
         boolean hasNext = cursor.moveToFirst();
         int i = 0;
         while (hasNext) {
+            String destLanguageIso = cursor.getString(cursor.getColumnIndex(
+                    DictionariesTable.LANGUAGE_ISO));
             String label = cursor.getString(cursor.getColumnIndex(DictionariesTable.LABEL));
             long dictionaryId = cursor.getLong(cursor.getColumnIndex(DictionariesTable.ID));
-            Dictionary dictionary = new Dictionary(label, getTranslationsByDictionaryId(dictionaryId), dictionaryId, deckId);
+            Dictionary dictionary = new Dictionary(destLanguageIso, label,
+                    getTranslationsByDictionaryId(dictionaryId), dictionaryId, deckId);
             dictionaries[i] = dictionary;
             i++;
             hasNext = cursor.moveToNext();
@@ -258,12 +263,14 @@ public class DbManager {
         boolean hasNext = cursor.moveToFirst();
         int i = 0;
         while(hasNext){
-            Deck deck = new Deck(cursor.getString(cursor.getColumnIndex(DecksTable.LABEL)),
+            Deck deck = new Deck(
+                    cursor.getString(cursor.getColumnIndex(DecksTable.LABEL)),
                     cursor.getString(cursor.getColumnIndex(DecksTable.PUBLISHER)),
                     cursor.getString(cursor.getColumnIndex(DecksTable.EXTERNAL_ID)),
                     cursor.getLong(cursor.getColumnIndex(DecksTable.ID)),
                     cursor.getLong(cursor.getColumnIndex(DecksTable.CREATION_TIMESTAMP)),
-                    cursor.getInt(cursor.getColumnIndex(DecksTable.LOCKED)) == 1);
+                    cursor.getInt(cursor.getColumnIndex(DecksTable.LOCKED)) == 1,
+                    cursor.getString(cursor.getColumnIndex(DecksTable.SOURCE_LANGUAGE_ISO)));
 
             decks[i] = deck;
             hasNext = cursor.moveToNext();
@@ -514,8 +521,11 @@ public class DbManager {
     }
 
     private final Dictionary[] INCLUDED_DATA = new Dictionary[] {
-            new Dictionary("Arabic", new Dictionary.Translation[] {}, NO_VALUE_ID, NO_VALUE_ID),
-            new Dictionary("Farsi", new Dictionary.Translation[] {}, NO_VALUE_ID, NO_VALUE_ID),
-            new Dictionary("Pashto", new Dictionary.Translation[] {}, NO_VALUE_ID, NO_VALUE_ID),
+            new Dictionary("ar", "Arabic", new Dictionary.Translation[] {},
+                    NO_VALUE_ID, NO_VALUE_ID),
+            new Dictionary("fa", "Farsi", new Dictionary.Translation[] {},
+                    NO_VALUE_ID, NO_VALUE_ID),
+            new Dictionary("ps", "Pashto", new Dictionary.Translation[] {},
+                    NO_VALUE_ID, NO_VALUE_ID),
     };
 }

--- a/app/src/main/java/org/mercycorps/translationcards/data/DbManager.java
+++ b/app/src/main/java/org/mercycorps/translationcards/data/DbManager.java
@@ -181,17 +181,18 @@ public class DbManager {
         dbh.getWritableDatabase().delete(DecksTable.TABLE_NAME, whereClause, whereArgs);
     }
 
-    public long addDictionary(SQLiteDatabase writableDatabase, String label, int itemIndex,
-                              long deckId) {
+    public long addDictionary(SQLiteDatabase writableDatabase, String destIsoCode, String label,
+                              int itemIndex, long deckId) {
         ContentValues values = new ContentValues();
+        values.put(DictionariesTable.LANGUAGE_ISO, destIsoCode);
         values.put(DictionariesTable.LABEL, label);
         values.put(DictionariesTable.ITEM_INDEX, itemIndex);
         values.put(DictionariesTable.DECK_ID, deckId);
         return writableDatabase.insert(DictionariesTable.TABLE_NAME, null, values);
     }
 
-    public long addDictionary(String label, int itemIndex, long deckId) {
-        return addDictionary(dbh.getWritableDatabase(), label, itemIndex, deckId);
+    public long addDictionary(String destIsoCode, String label, int itemIndex, long deckId) {
+        return addDictionary(dbh.getWritableDatabase(), destIsoCode, label, itemIndex, deckId);
     }
 
     public long addTranslation(SQLiteDatabase writableDatabase,
@@ -338,7 +339,7 @@ public class DbManager {
     public String getTranslationLanguagesForDeck(long deckDbId) {
         Cursor cursor = dbh.getReadableDatabase().query(
                 DictionariesTable.TABLE_NAME,
-                new String[]{DictionariesTable.LABEL},
+                new String[]{DictionariesTable.LANGUAGE_ISO},
                 DictionariesTable.DECK_ID + " = ?",
                 new String[]{String.valueOf(deckDbId)}, null, null,
                 String.format("%s ASC", DictionariesTable.LABEL));
@@ -347,7 +348,8 @@ public class DbManager {
         String delimiter = "   ";
         boolean hasNext = cursor.moveToFirst();
         while(hasNext) {
-            String translationLanguage = cursor.getString(cursor.getColumnIndex(DictionariesTable.LABEL));
+            String translationLanguage = cursor.getString(
+                    cursor.getColumnIndex(DictionariesTable.LANGUAGE_ISO));
             translationLanguages += translationLanguage.toUpperCase() + delimiter;
             hasNext = cursor.moveToNext();
         }
@@ -461,7 +463,8 @@ public class DbManager {
             for (int dictionaryIndex = 0; dictionaryIndex < INCLUDED_DATA.length;
                  dictionaryIndex++) {
                 Dictionary dictionary = INCLUDED_DATA[dictionaryIndex];
-                long dictionaryId = addDictionary(db, dictionary.getLabel(), dictionaryIndex,
+                long dictionaryId = addDictionary(db, dictionary.getDestLanguageIso(),
+                        dictionary.getLabel(), dictionaryIndex,
                         defaultDeckId);
                 for (int translationIndex = 0;
                      translationIndex < dictionary.getTranslationCount();

--- a/app/src/main/java/org/mercycorps/translationcards/data/Deck.java
+++ b/app/src/main/java/org/mercycorps/translationcards/data/Deck.java
@@ -1,5 +1,6 @@
 package org.mercycorps.translationcards.data;
 
+import android.content.Context;
 import android.os.Parcelable;
 
 import java.io.Serializable;
@@ -20,6 +21,8 @@ public class Deck implements Serializable {
     private final long timestamp;
     private final boolean locked;
     private final String srcLanguageIso;
+    // The dictionaries list is lazily initialized.
+    private Dictionary[] dictionaries;
 
     public Deck(String label, String publisher, String externalId, long dbId, long timestamp,
                 boolean locked, String srcLanguageIso) {
@@ -30,6 +33,7 @@ public class Deck implements Serializable {
         this.timestamp = timestamp;
         this.locked = locked;
         this.srcLanguageIso = srcLanguageIso;
+        dictionaries = null;
     }
 
     public Deck(String label, String publisher, String externalId, long timestamp, boolean locked,
@@ -70,5 +74,13 @@ public class Deck implements Serializable {
 
     public String getSrcLanguageIso() {
         return srcLanguageIso;
+    }
+
+    public Dictionary[] getDictionaries(Context context) {
+        if (dictionaries == null) {
+            DbManager dbm = new DbManager(context);
+            dictionaries = dbm.getDictionariesForDeck(dbId);
+        }
+        return dictionaries;
     }
 }

--- a/app/src/main/java/org/mercycorps/translationcards/data/Deck.java
+++ b/app/src/main/java/org/mercycorps/translationcards/data/Deck.java
@@ -19,19 +19,22 @@ public class Deck implements Serializable {
     private final long dbId;
     private final long timestamp;
     private final boolean locked;
+    private final String srcLanguageIso;
 
     public Deck(String label, String publisher, String externalId, long dbId, long timestamp,
-                boolean locked) {
+                boolean locked, String srcLanguageIso) {
         this.label = label;
         this.publisher = publisher;
         this.externalId = externalId;
         this.dbId = dbId;
         this.timestamp = timestamp;
         this.locked = locked;
+        this.srcLanguageIso = srcLanguageIso;
     }
 
-    public Deck(String label, String publisher, String externalId, long timestamp, boolean locked) {
-        this(label, publisher, externalId, -1, timestamp, locked);
+    public Deck(String label, String publisher, String externalId, long timestamp, boolean locked,
+                String srcLanguageIso) {
+        this(label, publisher, externalId, -1, timestamp, locked, srcLanguageIso);
     }
 
     public String getLabel() {
@@ -63,5 +66,9 @@ public class Deck implements Serializable {
 
     public boolean isLocked() {
         return locked;
+    }
+
+    public String getSrcLanguageIso() {
+        return srcLanguageIso;
     }
 }

--- a/app/src/main/java/org/mercycorps/translationcards/data/Dictionary.java
+++ b/app/src/main/java/org/mercycorps/translationcards/data/Dictionary.java
@@ -72,11 +72,6 @@ public class Dictionary {
         return deckId;
     }
 
-    public String getDisplayName(Context context) {
-        return (label == null) ?
-                LanguageDisplayUtil.getLanguageDisplayName(context, destLanguageIso) : label;
-    }
-
     /**
      * Contains information about a single phrase.
      */

--- a/app/src/main/java/org/mercycorps/translationcards/data/Dictionary.java
+++ b/app/src/main/java/org/mercycorps/translationcards/data/Dictionary.java
@@ -31,7 +31,7 @@ import java.io.Serializable;
  *
  * @author nick.c.worden@gmail.com (Nick Worden)
  */
-public class Dictionary {
+public class Dictionary implements Serializable {
 
     private final long dbId;
     private final long deckId;

--- a/app/src/main/java/org/mercycorps/translationcards/data/Dictionary.java
+++ b/app/src/main/java/org/mercycorps/translationcards/data/Dictionary.java
@@ -20,6 +20,8 @@ import android.content.Context;
 import android.content.res.AssetFileDescriptor;
 import android.media.MediaPlayer;
 
+import org.mercycorps.translationcards.ui.LanguageDisplayUtil;
+
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.Serializable;
@@ -68,6 +70,11 @@ public class Dictionary {
 
     public long getDeckId() {
         return deckId;
+    }
+
+    public String getDisplayName(Context context) {
+        return (label == null) ?
+                LanguageDisplayUtil.getLanguageDisplayName(context, destLanguageIso) : label;
     }
 
     /**

--- a/app/src/main/java/org/mercycorps/translationcards/data/Dictionary.java
+++ b/app/src/main/java/org/mercycorps/translationcards/data/Dictionary.java
@@ -31,16 +31,23 @@ import java.io.Serializable;
  */
 public class Dictionary {
 
+    private final String destLanguageIso;
     private final String label;
     private final Translation[] translations;
     private final long dbId;
     private final long deckId;
 
-    public Dictionary(String label, Translation[] translations, long dbId, long deckId) {
+    public Dictionary(String destLanguageIso, String label, Translation[] translations, long dbId,
+                      long deckId) {
+        this.destLanguageIso = destLanguageIso;
         this.label = label;
         this.translations = translations;
         this.dbId = dbId;
         this.deckId = deckId;
+    }
+
+    public String getDestLanguageIso() {
+        return destLanguageIso;
     }
 
     public String getLabel() {

--- a/app/src/main/java/org/mercycorps/translationcards/data/Dictionary.java
+++ b/app/src/main/java/org/mercycorps/translationcards/data/Dictionary.java
@@ -33,11 +33,11 @@ import java.io.Serializable;
  */
 public class Dictionary {
 
-    private final String destLanguageIso;
-    private final String label;
-    private final Translation[] translations;
     private final long dbId;
     private final long deckId;
+    private final String destLanguageIso;
+    private final String label;
+    private Translation[] translations;
 
     public Dictionary(String destLanguageIso, String label, Translation[] translations, long dbId,
                       long deckId) {
@@ -46,6 +46,14 @@ public class Dictionary {
         this.translations = translations;
         this.dbId = dbId;
         this.deckId = deckId;
+    }
+
+    Dictionary(long dbId, long deckId, String destLanguageIso, String label) {
+        this.dbId = dbId;
+        this.deckId = deckId;
+        this.destLanguageIso = destLanguageIso;
+        this.label = label;
+        translations = null;
     }
 
     public String getDestLanguageIso() {

--- a/app/src/main/java/org/mercycorps/translationcards/porting/TxcPortingUtility.java
+++ b/app/src/main/java/org/mercycorps/translationcards/porting/TxcPortingUtility.java
@@ -425,8 +425,10 @@ public class TxcPortingUtility {
             long dictionaryId = dbm.addDictionary(dictionary.language, null, i, deckId);
             for (int j = 0; j < dictionary.cards.size(); j++) {
                 ImportSpecCard card = dictionary.cards.get(j);
+                File cardFile = new File(importSpec.dir, card.filename);
                 dbm.addTranslation(
-                        dictionaryId, card.label, false, card.filename, j, card.translatedText);
+                        dictionaryId, card.label, false, cardFile.getAbsolutePath(), j,
+                        card.translatedText);
             }
         }
     }

--- a/app/src/main/java/org/mercycorps/translationcards/porting/TxcPortingUtility.java
+++ b/app/src/main/java/org/mercycorps/translationcards/porting/TxcPortingUtility.java
@@ -404,7 +404,7 @@ public class TxcPortingUtility {
                 importSpec.externalId, importSpec.hash, importSpec.locked, importSpec.srcLanguage);
         for (int i = 0; i < importSpec.dictionaries.size(); i++) {
             ImportSpecDictionary dictionary = importSpec.dictionaries.get(i);
-            long dictionaryId = dbm.addDictionary(dictionary.language, i, deckId);
+            long dictionaryId = dbm.addDictionary(dictionary.language, null, i, deckId);
             for (int j = 0; j < dictionary.cards.size(); j++) {
                 ImportSpecCard card = dictionary.cards.get(j);
                 dbm.addTranslation(

--- a/app/src/main/java/org/mercycorps/translationcards/ui/LanguageDisplayUtil.java
+++ b/app/src/main/java/org/mercycorps/translationcards/ui/LanguageDisplayUtil.java
@@ -1,0 +1,28 @@
+package org.mercycorps.translationcards.ui;
+
+import android.content.Context;
+
+import org.mercycorps.translationcards.R;
+
+/**
+ * A utility class for displaying information about languages keyed by ISO code.
+ *
+ * @author nick.c.worden@gmail.com (Nick Worden)
+ */
+public class LanguageDisplayUtil {
+
+    public static String getLanguageDisplayName(Context context, String isoCode) {
+        switch (isoCode) {
+            case "ar":
+                return context.getString(R.string.name_ar);
+            case "en":
+                return context.getString(R.string.name_en);
+            case "fa":
+                return context.getString(R.string.name_fa);
+            case "ps":
+                return context.getString(R.string.name_ps);
+            default:
+                return null;
+        }
+    }
+}

--- a/app/src/main/java/org/mercycorps/translationcards/ui/LanguageDisplayUtil.java
+++ b/app/src/main/java/org/mercycorps/translationcards/ui/LanguageDisplayUtil.java
@@ -24,6 +24,20 @@ public class LanguageDisplayUtil {
                 dictionary.getLabel();
     }
 
+    public static String getDestLanguageListDisplay(Context context, Deck deck, String delimiter) {
+        Dictionary[] dictionaries = deck.getDictionaries(context);
+        if (dictionaries.length == 0) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append(getDestLanguageDisplayName(context, dictionaries[0]));
+        for (int i = 1; i < dictionaries.length; i++) {
+            sb.append(delimiter);
+            sb.append(getDestLanguageDisplayName(context, dictionaries[i]));
+        }
+        return sb.toString();
+    }
+
     private static String getLanguageDisplayName(Context context, String isoCode) {
         switch (isoCode) {
             case "ar":

--- a/app/src/main/java/org/mercycorps/translationcards/ui/LanguageDisplayUtil.java
+++ b/app/src/main/java/org/mercycorps/translationcards/ui/LanguageDisplayUtil.java
@@ -14,12 +14,12 @@ import org.mercycorps.translationcards.data.Dictionary;
 public class LanguageDisplayUtil {
 
     public static String getSourceLanguageDisplayName(Context context, Deck deck) {
-        return (deck.getLabel() == null) ?
+        return isNullOrEmpty(deck.getLabel()) ?
                 getLanguageDisplayName(context, deck.getSrcLanguageIso()) : deck.getLabel();
     }
 
     public static String getDestLanguageDisplayName(Context context, Dictionary dictionary) {
-        return (dictionary.getLabel() == null) ?
+        return isNullOrEmpty(dictionary.getLabel()) ?
                 getLanguageDisplayName(context, dictionary.getDestLanguageIso()) :
                 dictionary.getLabel();
     }
@@ -49,7 +49,12 @@ public class LanguageDisplayUtil {
             case "ps":
                 return context.getString(R.string.name_ps);
             default:
-                return null;
+                // Better than nothing.
+                return isoCode;
         }
+    }
+
+    private static boolean isNullOrEmpty(String val) {
+        return (val == null) || val.isEmpty();
     }
 }

--- a/app/src/main/java/org/mercycorps/translationcards/ui/LanguageDisplayUtil.java
+++ b/app/src/main/java/org/mercycorps/translationcards/ui/LanguageDisplayUtil.java
@@ -3,6 +3,8 @@ package org.mercycorps.translationcards.ui;
 import android.content.Context;
 
 import org.mercycorps.translationcards.R;
+import org.mercycorps.translationcards.data.Deck;
+import org.mercycorps.translationcards.data.Dictionary;
 
 /**
  * A utility class for displaying information about languages keyed by ISO code.
@@ -11,7 +13,18 @@ import org.mercycorps.translationcards.R;
  */
 public class LanguageDisplayUtil {
 
-    public static String getLanguageDisplayName(Context context, String isoCode) {
+    public static String getSourceLanguageDisplayName(Context context, Deck deck) {
+        return (deck.getLabel() == null) ?
+                getLanguageDisplayName(context, deck.getSrcLanguageIso()) : deck.getLabel();
+    }
+
+    public static String getDestLanguageDisplayName(Context context, Dictionary dictionary) {
+        return (dictionary.getLabel() == null) ?
+                getLanguageDisplayName(context, dictionary.getDestLanguageIso()) :
+                dictionary.getLabel();
+    }
+
+    private static String getLanguageDisplayName(Context context, String isoCode) {
         switch (isoCode) {
             case "ar":
                 return context.getString(R.string.name_ar);

--- a/app/src/main/res/values/language_info_strings.xml
+++ b/app/src/main/res/values/language_info_strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="name_ar">Arabic</string>
+    <string name="name_en">English</string>
+    <string name="name_fa">Farsi</string>
+    <string name="name_ps">Pashto</string>
+</resources>


### PR DESCRIPTION
LMK what you think about adding support for custom language labels in JSON sooner rather than later. The advantage of doing that is that users who export a deck from before I make these changes can have their export include a sensible name for the language. I added a column for the language ISO codes to the dictionaries table and populated existing ones with "xx"; in the app that's fine because it falls back to the label (which the user would already have defined as "Arabic" or whatever), but there's nowhere for that to go in the JSON yet and it get lost altogether. Might not matter much though (it sounds like John's not exporting from the app anyway).