### PR TITLE
#291

### DIFF
--- a/app/src/main/java/org/mercycorps/translationcards/activity/translations/CardListAdapter.java
+++ b/app/src/main/java/org/mercycorps/translationcards/activity/translations/CardListAdapter.java
@@ -112,8 +112,15 @@ public class CardListAdapter extends ArrayAdapter<Translation> {
     }
 
     public void update() {
+        updateTranslationCardStates();
         clear();
         addAll(translationService.getCurrentTranslations());
         notifyDataSetChanged();
+    }
+
+    private void updateTranslationCardStates() {
+        if (getCount() != translationService.getCurrentTranslations().size()) {
+            translationService.initializeCardStates();
+        }
     }
 }

--- a/app/src/test/java/org/mercycorps/translationcards/activity/TranslationsActivityTest.java
+++ b/app/src/test/java/org/mercycorps/translationcards/activity/TranslationsActivityTest.java
@@ -293,7 +293,7 @@ public class TranslationsActivityTest {
 
     @Test
     public void shouldUpdateTranslationsListOnResume() throws Exception {
-        when(translationService.getCurrentTranslations()).thenReturn(new ArrayList<Translation>())
+        when(translationService.getCurrentTranslations()).thenReturn(new ArrayList<Translation>(), new ArrayList<Translation>())
                 .thenReturn(Collections.singletonList(new Translation()));
         ShadowActivity shadowActivity = Shadows.shadowOf(translationsActivity);
         ListView listView = (ListView)translationsActivity.findViewById(R.id.translations_list);

--- a/app/src/test/java/org/mercycorps/translationcards/activity/translations/CardListAdapterTest.java
+++ b/app/src/test/java/org/mercycorps/translationcards/activity/translations/CardListAdapterTest.java
@@ -31,6 +31,7 @@ import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowAlertDialog;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -38,6 +39,7 @@ import javax.inject.Inject;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.robolectric.Shadows.shadowOf;
@@ -208,5 +210,25 @@ public class CardListAdapterTest {
         resultingView.findViewById(R.id.translation_card_edit).performClick();
         Deck retrievedDeck = (Deck)shadowOf(shadowOf(activity).getNextStartedActivity()).getExtras().get(DeckService.INTENT_KEY_DECK);
         assertEquals(basicDeck, retrievedDeck);
+    }
+
+    @Test
+    public void shouldNotUpdateTranslationCardStatesWhenListAdapterIsUpdatedWithSameNumberOfTranslations() {
+        when(mockTranslationService.getCurrentTranslations()).thenReturn(translations);
+
+        cardListAdapter.update();
+
+        verify(mockTranslationService, times(0)).initializeCardStates();
+    }
+
+    @Test
+    public void shouldUpdateTranslationCardStatesWhenListAdapterIsUpdatedWithDifferentNumberOfTranslations() {
+        List<Translation> longerTranslations = Arrays.asList(firstTranslation, secondTranslation);
+        when(mockTranslationService.getCurrentTranslations()).thenReturn(longerTranslations);
+
+        cardListAdapter.update();
+
+        verify(mockTranslationService).initializeCardStates();
+
     }
 }


### PR DESCRIPTION
 Reset expanded state of translations if one dictionary is of different length than another in a deck.

This is a fix to the story card, but seems temporary as our view and business logic are tightly coupled in the TranslationsActivity & CardsListAdapter. They both rely heavily on the TranslationService (which is a singleton) to set their view logic. It may be a good idea to revisit the TranslationService when refactoring the TranslationsActivity & CardsListAdapter.
