### PR TITLE
#301 change file MIME type for import deck dialog

### DIFF
--- a/app/src/main/java/org/mercycorps/translationcards/activity/Router.java
+++ b/app/src/main/java/org/mercycorps/translationcards/activity/Router.java
@@ -40,7 +40,7 @@ public class Router {
             activity.startActivityForResult(samsungIntent, Router.REQUEST_CODE_IMPORT_FILE_PICKER);
         } else {
             Intent fileIntent = new Intent(Intent.ACTION_GET_CONTENT);
-            fileIntent.setType("file/*");
+            fileIntent.setType("*/*");
             activity.startActivityForResult(fileIntent, Router.REQUEST_CODE_IMPORT_FILE_PICKER);
         }
     }


### PR DESCRIPTION
This change allows the user to choose any file from the file selection dialog. This means the user can select decks packaged with a .txc or a .zip extension. 